### PR TITLE
Prevent access of removed elements in StateStack

### DIFF
--- a/src/main/java/minicpbp/state/StateStack.java
+++ b/src/main/java/minicpbp/state/StateStack.java
@@ -49,8 +49,11 @@ public class StateStack<E> {
     }
 
     public E get(int index) {
+        if (index >= size.value()) {
+            throw new IndexOutOfBoundsException();
+        }
         return stack.get(index);
     }
 
-    public Iterator<E> iterator() { return stack.iterator();}
+    public Iterator<E> iterator() { return stack.subList(0, size.value()).iterator();}
 }


### PR DESCRIPTION
When a push to `StateStack` is restored, the pushed element is not removed from the `ArrayList` and instead `size` is simply decremented. This means that elements with index >= `size` should be ignored.

This PR adds a bound check when accessing a value and limits iterators to valid elements.