### PR TITLE
Handle roulette wheel selection where all marginals are 0

### DIFF
--- a/src/main/java/minicpbp/engine/core/SparseSetDomain.java
+++ b/src/main/java/minicpbp/engine/core/SparseSetDomain.java
@@ -173,6 +173,12 @@ public class SparseSetDomain implements IntDomain {
                 max = marginal(v);
             }
         }
+
+        // Prevents an infinite loop if something wrong happened during BP and all marginals are 0.
+        if (max == 0) {
+            return randomValue();
+        }
+
 	    // stochastic acceptance algorithm
 	    while (true) {
             int v = domainValues[rand.nextInt(s)];


### PR DESCRIPTION
Currently, all marginals can become 0 in rare cases (possibly when using `resetMarginalsBeforeBP=false`?). This causes infinite looping in `biasedWheelValue()`.

I've chosen to treat this case like if the marginals were equiprobable and keep going, but an alternate solution could be to throw an exception.